### PR TITLE
Fix CI caching and fix Python 3.9 bug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local
-          key: poetry-1.1.12-0
+          key: poetry-${{ matrix.python-version }}
 
       # Install Poetry. You could do this manually, or there are several actions that do this.
       # `snok/install-poetry` seems to be minimal yet complete, and really just calls out to
@@ -44,7 +44,7 @@ jobs:
       # cache it.
       - uses: snok/install-poetry@v1
         with:
-          version: 1.5.1
+          version: 1.8.5
           virtualenvs-create: true
           virtualenvs-in-project: true
 
@@ -56,7 +56,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: pydeps-${{ hashFiles('**/poetry.lock') }}
+          key: pydeps-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       # Install dependencies. `--no-root` means "install all dependencies but not the project
       # itself", which is what you want to avoid caching _your_ code. The `if` statement
@@ -79,6 +79,6 @@ jobs:
       # https://github.com/astral-sh/ruff/issues/8430
       # - run: poetry run ruff format --check
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vapor-steam"
-version = "1.6.0"
+version = "1.6.1"
 description = "TUI program to check the ProtonDB compatibility of all the games of a Steam user."
 authors = ["TabulateJarl8 <tabulatejarl8@gmail.com>"]
 license = "GPLv3"

--- a/vapor/main.py
+++ b/vapor/main.py
@@ -155,7 +155,7 @@ class SteamApp(App[None]):
 					id='user-rating',
 				),
 			),
-			DataTable[str | Text](zebra_stripes=True),
+			DataTable['str | Text'](zebra_stripes=True),
 			id='body',
 		)
 		yield Footer()


### PR DESCRIPTION
A bug in the CI cause a missed crash in Python 3.9 due to `from __future__ import annotations` not working for `DataTable[str | Text](zebra_stripes=True)`. This has been fixed by quoting the union as a string